### PR TITLE
Define valid sentence endings more strictly

### DIFF
--- a/gdex/__init__.py
+++ b/gdex/__init__.py
@@ -174,7 +174,10 @@ def _de_is_misparsed(sent: Span) -> bool:
         return True
 
     last_token = tokens[-1]
-    if last_token.pos_ != "PUNCT":
+    if last_token.text not in {".", "?", "!"}:
+        return True
+
+    if (sum((1 for t in tokens if t.tag_ == "$(")) % 2) != 0:
         return True
 
     return False

--- a/tests/test_gdex.py
+++ b/tests/test_gdex.py
@@ -54,6 +54,15 @@ def test_misparsed():
     assert_knockout("Ein Satz ohne Satzzeichen")
     assert_knockout("ein Satz, der mit Kleinbuchstaben beginnt.")
     assert_knockout(": Ein Satz mit Interpunktion am Anfang.")
+    assert_knockout("Ein Satz, der nach einem Komma geteilt wurde,")
+    assert_knockout("Der nächste Satz gehört inhaltlich eng zu diesem:")
+    assert_knockout(
+        (
+            '"Durch das Kriterium werden auch alle Sätze, die mit '
+            'Anführungszeichen beginnen und/oder enden, ausgeschlossen."'
+        )
+    )
+    assert_knockout('Die Kulisse habe "eine malerische Qualität."')
 
 
 def test_finite_verb_and_subject():


### PR DESCRIPTION
Also sentences that end with a punctuation token which could occur in the middle of a sentence, are penalized